### PR TITLE
Split the `arch` backend into `pacman`, `paru`, and `yay` using a shared helper

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3,10 +3,13 @@ pub mod arch;
 pub mod cargo;
 pub mod dnf;
 pub mod flatpak;
+pub mod pacman;
+pub mod paru;
 pub mod pip;
 pub mod pipx;
 pub mod rustup;
 pub mod xbps;
+pub mod yay;
 
 use std::{collections::BTreeMap, str::FromStr};
 

--- a/src/backend/pacman.rs
+++ b/src/backend/pacman.rs
@@ -1,0 +1,43 @@
+use crate::prelude::*;
+use anyhow::Result;
+use std::collections::BTreeMap;
+
+#[derive(Debug, Copy, Clone, Default, derive_more::Display)]
+pub struct Pacman;
+impl Pacman {
+    const PACMAN: Arch = Arch { command: "pacman" };
+}
+
+impl Backend for Pacman {
+    type PackageId = ArchPackageId;
+    type InstallOptions = ArchInstallOptions;
+    type RemoveOptions = ArchRemoveOptions;
+    type QueryInfo = ArchQueryInfo;
+    type Modification = ArchModification;
+
+    fn query_installed_packages(
+        config: &Config,
+    ) -> Result<BTreeMap<Self::PackageId, Self::QueryInfo>> {
+        Self::PACMAN.query_installed_packages(config)
+    }
+    fn install_packages(
+        packages: &BTreeMap<Self::PackageId, Self::InstallOptions>,
+        no_confirm: bool,
+        config: &Config,
+    ) -> Result<()> {
+        Self::PACMAN.install_packages(packages, no_confirm, config)
+    }
+    fn modify_packages(
+        packages: &BTreeMap<Self::PackageId, Self::Modification>,
+        config: &Config,
+    ) -> Result<()> {
+        Self::PACMAN.modify_packages(packages, config)
+    }
+    fn remove_packages(
+        packages: &BTreeMap<Self::PackageId, Self::RemoveOptions>,
+        no_confirm: bool,
+        config: &Config,
+    ) -> Result<()> {
+        Self::PACMAN.remove_packages(packages, no_confirm, config)
+    }
+}

--- a/src/backend/paru.rs
+++ b/src/backend/paru.rs
@@ -1,0 +1,43 @@
+use crate::prelude::*;
+use anyhow::Result;
+use std::collections::BTreeMap;
+
+#[derive(Debug, Copy, Clone, Default, derive_more::Display)]
+pub struct Paru;
+impl Paru {
+    const PARU: Arch = Arch { command: "paru" };
+}
+
+impl Backend for Paru {
+    type PackageId = ArchPackageId;
+    type InstallOptions = ArchInstallOptions;
+    type RemoveOptions = ArchRemoveOptions;
+    type QueryInfo = ArchQueryInfo;
+    type Modification = ArchModification;
+
+    fn query_installed_packages(
+        config: &Config,
+    ) -> Result<BTreeMap<Self::PackageId, Self::QueryInfo>> {
+        Self::PARU.query_installed_packages(config)
+    }
+    fn install_packages(
+        packages: &BTreeMap<Self::PackageId, Self::InstallOptions>,
+        no_confirm: bool,
+        config: &Config,
+    ) -> Result<()> {
+        Self::PARU.install_packages(packages, no_confirm, config)
+    }
+    fn modify_packages(
+        packages: &BTreeMap<Self::PackageId, Self::Modification>,
+        config: &Config,
+    ) -> Result<()> {
+        Self::PARU.modify_packages(packages, config)
+    }
+    fn remove_packages(
+        packages: &BTreeMap<Self::PackageId, Self::RemoveOptions>,
+        no_confirm: bool,
+        config: &Config,
+    ) -> Result<()> {
+        Self::PARU.remove_packages(packages, no_confirm, config)
+    }
+}

--- a/src/backend/xbps.rs
+++ b/src/backend/xbps.rs
@@ -10,14 +10,16 @@ use crate::prelude::*;
 #[derive(Debug, Copy, Clone, Default, derive_more::Display)]
 pub struct Xbps;
 
-pub struct XbpsMakeImplicit;
+pub struct XbpsModification {
+    make_implicit: bool,
+}
 
 impl Backend for Xbps {
     type PackageId = String;
     type RemoveOptions = ();
     type InstallOptions = ();
     type QueryInfo = ();
-    type Modification = XbpsMakeImplicit;
+    type Modification = XbpsModification;
 
     fn query_installed_packages(
         _: &Config,
@@ -78,9 +80,12 @@ impl Backend for Xbps {
         _: &Config,
     ) -> Result<()> {
         run_args(
-            ["xbps-pkgdb", "-m", "auto"]
-                .into_iter()
-                .chain(packages.keys().map(String::as_str)),
+            ["xbps-pkgdb", "-m", "auto"].into_iter().chain(
+                packages
+                    .iter()
+                    .filter(|(_, m)| m.make_implicit)
+                    .map(|(p, _)| p.as_str()),
+            ),
         )
     }
 }

--- a/src/backend/yay.rs
+++ b/src/backend/yay.rs
@@ -1,0 +1,43 @@
+use crate::prelude::*;
+use anyhow::Result;
+use std::collections::BTreeMap;
+
+#[derive(Debug, Copy, Clone, Default, derive_more::Display)]
+pub struct Yay;
+impl Yay {
+    const YAY: Arch = Arch { command: "yay" };
+}
+
+impl Backend for Yay {
+    type PackageId = ArchPackageId;
+    type InstallOptions = ArchInstallOptions;
+    type RemoveOptions = ArchRemoveOptions;
+    type QueryInfo = ArchQueryInfo;
+    type Modification = ArchModification;
+
+    fn query_installed_packages(
+        config: &Config,
+    ) -> Result<BTreeMap<Self::PackageId, Self::QueryInfo>> {
+        Self::YAY.query_installed_packages(config)
+    }
+    fn install_packages(
+        packages: &BTreeMap<Self::PackageId, Self::InstallOptions>,
+        no_confirm: bool,
+        config: &Config,
+    ) -> Result<()> {
+        Self::YAY.install_packages(packages, no_confirm, config)
+    }
+    fn modify_packages(
+        packages: &BTreeMap<Self::PackageId, Self::Modification>,
+        config: &Config,
+    ) -> Result<()> {
+        Self::YAY.modify_packages(packages, config)
+    }
+    fn remove_packages(
+        packages: &BTreeMap<Self::PackageId, Self::RemoveOptions>,
+        no_confirm: bool,
+        config: &Config,
+    ) -> Result<()> {
+        Self::YAY.remove_packages(packages, no_confirm, config)
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,97 +1,36 @@
-use std::fs::{create_dir_all, File};
-use std::io::{ErrorKind, Write};
+use anyhow::anyhow;
 use std::path::Path;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
 // Update the master README if fields change.
-/// Config for the program, as listed in `$XDG_CONFIG_HOME/pacdef/pacdef.toml`.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Config {
-    /// The AUR helper to use for Arch Linux.
-    #[serde(default = "aur_helper")]
-    pub aur_helper: String,
     /// Additional arguments to pass to `aur_helper` when removing a package.
-    #[serde(default)]
     pub aur_rm_args: Vec<String>,
     /// Install Flatpak packages system-wide
-    #[serde(default = "yes")]
     pub flatpak_systemwide: bool,
-    /// Warn the user when a group is not a symlink.
-    #[serde(default = "yes")]
-    pub warn_not_symlinks: bool,
-    /// Backends the user does not want to use even though the binary exists.
-    #[serde(default)]
-    pub disabled_backends: Vec<String>,
-    /// Choose whether to use pipx instead of pip for python package management
-    #[serde(default = "pip")]
-    pub pip_binary: String,
 }
-
-fn yes() -> bool {
-    true
-}
-
-fn aur_helper() -> String {
-    "paru".into()
-}
-
-fn pip() -> String {
-    "pip".into()
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            aur_rm_args: vec![],
+            flatpak_systemwide: true,
+        }
+    }
 }
 
 impl Config {
     /// Load the config file from a users pacdef config folder.
-    ///
-    /// # Errors
-    /// - If a config file cannot be found.
     pub fn load(pacdef_dir: &Path) -> Result<Self> {
-        let config_file = pacdef_dir.join("config.toml");
+        let config_file_path = pacdef_dir.join("config.toml");
 
-        let content = match std::fs::read_to_string(config_file) {
-            Ok(content) => content,
-            Err(e) => {
-                if e.kind() == ErrorKind::NotFound {
-                    bail!("config file not found")
-                }
-                bail!("unexpected error occurred: {e:?}");
-            }
-        };
-
-        toml::from_str(&content).context("parsing toml config")
-    }
-
-    /// Save the instance of [`Config`] to disk.
-    ///
-    /// # Errors
-    ///
-    /// This function will return an error if the config file cannot be saved to disk.
-    pub fn save(&self, file: &Path) -> Result<()> {
-        let content = toml::to_string(&self).context("converting Config to toml")?;
-
-        let parent = file.parent().context("getting parent of config dir")?;
-        if !parent.is_dir() {
-            create_dir_all(parent)
-                .with_context(|| format!("creating dir {}", parent.to_string_lossy()))?;
+        if !config_file_path.is_file() {
+            return Err(anyhow!("config file not found at: {config_file_path:?}"));
         }
 
-        let mut output = File::create(file).context("creating default config file")?;
-        write!(output, "{content}").context("writing default config")?;
-
-        Ok(())
-    }
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            aur_helper: "paru".into(),
-            aur_rm_args: vec![],
-            flatpak_systemwide: true,
-            warn_not_symlinks: true,
-            disabled_backends: vec![],
-            pip_binary: "pip".into(),
-        }
+        toml::from_str(&std::fs::read_to_string(config_file_path).context("reading config file")?)
+            .context("parsing toml config")
     }
 }

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -2,15 +2,10 @@ use crate::prelude::*;
 use anyhow::{anyhow, Context, Result};
 use walkdir::{DirEntry, WalkDir};
 
-use std::{
-    collections::BTreeMap,
-    fs::read_to_string,
-    ops::{Deref, DerefMut},
-    path::Path,
-};
+use std::{collections::BTreeMap, fs::read_to_string, path::Path};
 
 /// A type representing a users group files with all their packages
-#[derive(Debug, Default)]
+#[derive(Debug, Default, derive_more::Deref, derive_more::DerefMut)]
 pub struct Groups(BTreeMap<String, PackagesInstall>);
 
 impl Groups {
@@ -25,10 +20,7 @@ impl Groups {
         packages
     }
 
-    /// Loads Groups from a users pacdef config folder.
-    ///
-    /// # Errors
-    ///  - If the Group config file cannot be found.
+    /// Loads [`Groups`] from a users pacdef config folder.
     pub fn load(group_dir: &Path) -> Result<Self> {
         let mut groups = Self::default();
 
@@ -60,18 +52,5 @@ impl Groups {
             groups.insert(group_name, packages);
         }
         Ok(groups)
-    }
-}
-
-impl Deref for Groups {
-    type Target = BTreeMap<String, PackagesInstall>;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for Groups {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
     }
 }

--- a/src/packages.rs
+++ b/src/packages.rs
@@ -300,8 +300,11 @@ generate_structs!(
     cargo: Cargo,
     dnf: Dnf,
     flatpak: Flatpak,
+    pacman: Pacman,
+    paru: Paru,
     pip: Pip,
     pipx: Pipx,
     rustup: Rustup,
-    xbps: Xbps
+    xbps: Xbps,
+    yay: Yay
 );

--- a/src/packages.rs
+++ b/src/packages.rs
@@ -129,11 +129,9 @@ macro_rules! impl_packages_ids {
 
                 let installed = PackagesQuery::installed(config)?;
 
-                let mut missing = requested
+                let missing = requested
                     .into_packages_ids()
                     .difference(&installed.into_packages_ids());
-
-                missing.clear_backends(&config.disabled_backends);
 
                 Ok(missing)
             }
@@ -142,13 +140,9 @@ macro_rules! impl_packages_ids {
 
                 let installed = PackagesQuery::installed(config)?;
 
-                let mut unmanaged = installed
+                Ok(installed
                     .into_packages_ids()
-                    .difference(&requested.into_packages_ids());
-
-                unmanaged.clear_backends(&config.disabled_backends);
-
-                Ok(unmanaged)
+                    .difference(&requested.into_packages_ids()))
             }
         }
     };
@@ -303,7 +297,6 @@ macro_rules! generate_structs {
 
 generate_structs!(
     apt: Apt,
-    arch: Arch,
     cargo: Cargo,
     dnf: Dnf,
     flatpak: Flatpak,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,12 +1,17 @@
-pub use crate::backend::apt::{Apt, AptMakeImplicit, AptQueryInfo};
-pub use crate::backend::arch::{Arch, ArchMakeImplicit, ArchQueryInfo};
+pub use crate::backend::apt::{Apt, AptModification, AptQueryInfo};
+pub use crate::backend::arch::{
+    Arch, ArchInstallOptions, ArchModification, ArchPackageId, ArchQueryInfo, ArchRemoveOptions,
+};
 pub use crate::backend::cargo::Cargo;
 pub use crate::backend::dnf::{Dnf, DnfInstallOptions, DnfQueryInfo};
 pub use crate::backend::flatpak::{Flatpak, FlatpakQueryInfo};
+pub use crate::backend::pacman::Pacman;
+pub use crate::backend::paru::Paru;
 pub use crate::backend::pip::{Pip, PipQueryInfo};
 pub use crate::backend::pipx::Pipx;
 pub use crate::backend::rustup::{Rustup, RustupPackageId};
-pub use crate::backend::xbps::{Xbps, XbpsMakeImplicit};
+pub use crate::backend::xbps::{Xbps, XbpsModification};
+pub use crate::backend::yay::Yay;
 pub use crate::backend::{AnyBackend, Backend};
 pub use crate::cli::CleanPackageAction;
 pub use crate::cli::MainArguments;


### PR DESCRIPTION
Also improved the `Xbps`, `Apt` and `Arch` modification structs to standard structs to allow future options to be added more easily.