### PR TITLE
cargo support for feature arrays

### DIFF
--- a/src/backend/arch.rs
+++ b/src/backend/arch.rs
@@ -62,7 +62,10 @@ impl Arch {
             [self.command, "--sync"]
                 .into_iter()
                 .chain(Some("--no_confirm").filter(|_| no_confirm))
-                .chain(packages.keys().map(String::as_str)),
+                .chain(packages.keys().map(String::as_str))
+                .chain(packages.values().flat_map(|dependencies| {
+                    dependencies.optional_deps.iter().map(String::as_str)
+                })),
         )
     }
 


### PR DESCRIPTION
Fixes arch install function for installing the optional_deps array and cargo now has support for supporting feature arrays among git remotes and other feature related boolean flag.