### PR TITLE
make unmanaged output valid group toml syntax

### DIFF
--- a/src/backends/all.rs
+++ b/src/backends/all.rs
@@ -1,3 +1,4 @@
+use serde::Serialize;
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::prelude::*;
@@ -35,7 +36,7 @@ macro_rules! to_package_ids {
 
 macro_rules! package_ids {
     ($($backend:ident),*) => {
-        #[derive(Debug, Clone, Default)]
+        #[derive(Debug, Clone, Default, Serialize)]
         #[allow(non_snake_case)]
         pub struct PackageIds {
             $(

--- a/src/core.rs
+++ b/src/core.rs
@@ -95,7 +95,7 @@ impl UnmanagedPackageAction {
         if unmanaged.is_empty() {
             eprintln!("no unmanaged packages");
         } else {
-            println!("{unmanaged}");
+            println!("{}", toml::to_string_pretty(&unmanaged)?);
         }
 
         Ok(())


### PR DESCRIPTION
Idea from #14, this could be used as method for doing a package review, for example:

`pacdef unmanaged > groups/unmanaged.toml`
`nvim groups/` Copy wanted packages into regular group files
`rm groups/unmanaged.toml`
`pacdef sync`