### PR TITLE
fix arch not recognizing optional dependencies

### DIFF
--- a/src/backends/all.rs
+++ b/src/backends/all.rs
@@ -22,11 +22,22 @@ macro_rules! is_empty {
         }
     };
 }
+
 macro_rules! to_package_ids {
     ($($backend:ident),*) => {
         pub fn to_package_ids(&self) -> PackageIds {
             PackageIds {
                 $( $backend: self.$backend.keys().cloned().collect() ),*
+            }
+        }
+    };
+}
+
+macro_rules! package_convert {
+    ($($backend:ident),*) => {
+        pub fn to_package_ids(&self) -> PackageIds {
+            PackageIds {
+                $( $backend: self.$backend.keys().map(|key| {<$backend as Backend>::include_implicit(key, self.$backend.get(key).unwrap())}).flat_map(Vec::into_iter).collect() ),*
             }
         }
     };
@@ -199,7 +210,7 @@ macro_rules! install_options {
         impl InstallOptions {
             append!($($backend),*);
             is_empty!($($backend),*);
-            to_package_ids!($($backend),*);
+            package_convert!($($backend),*);
 
             pub fn map_install_packages(mut self, config: &Config) -> Result<Self> {
                 $(

--- a/src/backends/all.rs
+++ b/src/backends/all.rs
@@ -33,15 +33,15 @@ macro_rules! to_package_ids {
     };
 }
 
-macro_rules! package_convert {
-    ($($backend:ident),*) => {
-        pub fn to_package_ids(&self) -> PackageIds {
-            PackageIds {
-                $( $backend: self.$backend.keys().map(|key| {<$backend as Backend>::include_implicit(key, self.$backend.get(key).unwrap())}).flat_map(Vec::into_iter).collect() ),*
-            }
-        }
-    };
-}
+// macro_rules! package_convert {
+//     ($($backend:ident),*) => {
+//         pub fn to_package_ids(&self) -> PackageIds {
+//             PackageIds {
+//                 $( $backend: self.$backend.keys().map(|key| {<$backend as Backend>::include_implicit(key, self.$backend.get(key).unwrap())}).flat_map(Vec::into_iter).collect() ),*
+//             }
+//         }
+//     };
+// }
 
 macro_rules! any {
     ($($backend:ident),*) => {
@@ -210,7 +210,7 @@ macro_rules! install_options {
         impl InstallOptions {
             append!($($backend),*);
             is_empty!($($backend),*);
-            package_convert!($($backend),*);
+            to_package_ids!($($backend),*);
 
             pub fn map_install_packages(mut self, config: &Config) -> Result<Self> {
                 $(

--- a/src/backends/all.rs
+++ b/src/backends/all.rs
@@ -33,16 +33,6 @@ macro_rules! to_package_ids {
     };
 }
 
-// macro_rules! package_convert {
-//     ($($backend:ident),*) => {
-//         pub fn to_package_ids(&self) -> PackageIds {
-//             PackageIds {
-//                 $( $backend: self.$backend.keys().map(|key| {<$backend as Backend>::include_implicit(key, self.$backend.get(key).unwrap())}).flat_map(Vec::into_iter).collect() ),*
-//             }
-//         }
-//     };
-// }
-
 macro_rules! any {
     ($($backend:ident),*) => {
         #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, derive_more::FromStr, derive_more::Display)]

--- a/src/backends/arch.rs
+++ b/src/backends/arch.rs
@@ -23,6 +23,16 @@ impl Backend for Arch {
     type QueryInfo = ArchQueryInfo;
     type InstallOptions = ArchInstallOptions;
 
+    fn include_implicit(key: &str, value: &Self::InstallOptions) -> Vec<String> {
+        let mut packages = vec![key.to_owned()];
+
+        for package in &value.optional_deps {
+            packages.push(package.clone());
+        }
+
+        packages
+    }
+
     fn map_managed_packages(
         mut packages: BTreeMap<String, Self::InstallOptions>,
         config: &Config,
@@ -55,11 +65,17 @@ impl Backend for Arch {
                 )?;
 
                 for group_package in group_packages.lines() {
-                    let overridden =
-                        packages.insert(group_package.to_string(), install_options.clone());
+                    let mut overridden = packages
+                        .insert(group_package.to_string(), Self::InstallOptions::default())
+                        .is_some();
+                    for opts in &install_options.optional_deps {
+                        overridden |= packages
+                            .insert(opts.to_string(), Self::InstallOptions::default())
+                            .is_some();
+                    }
 
-                    if overridden.is_some() {
-                        log::warn!("arch package {group_package} has been overridden by the {group} package group");
+                    if overridden {
+                        log::warn!("arch package {group_package} or one of its dependencies has been overridden by the {group} package group");
                     }
                 }
             }

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -30,10 +30,6 @@ pub trait Backend {
     type QueryInfo;
     type InstallOptions;
 
-    fn include_implicit(key: &str, _value: &Self::InstallOptions) -> Vec<String> {
-        vec![key.to_owned()]
-    }
-
     fn map_managed_packages(
         packages: BTreeMap<String, Self::InstallOptions>,
         config: &Config,

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -30,6 +30,10 @@ pub trait Backend {
     type QueryInfo;
     type InstallOptions;
 
+    fn include_implicit(key: &str, _value: &Self::InstallOptions) -> Vec<String> {
+        vec![key.to_owned()]
+    }
+
     fn map_managed_packages(
         packages: BTreeMap<String, Self::InstallOptions>,
         config: &Config,


### PR DESCRIPTION
This fixes a bug where 

```
Arch = [
	{ package = "pipewire", optional_deps = [
		"pipewire-alsa",
		"pipewire-jack",
		"pipewire-pulse",
		"wireplumber",         
		"libpulse",            
		"gst-plugin-pipewire",
	] },
]
```

does not recognize any of the optional dependencies.