### PR TITLE
feat: Add remote ref option to flatpak

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ dnf = [
 ]
 flatpak = [
  "metapac",
- { package = "metapac" }
+ { package = "metapac", remote = "flathub" }
 ]
 pipx = [
  "metapac",


### PR DESCRIPTION
Adds remote ref option to flatpak, allowing users to select which remote to pick for packages.