### PR TITLE
Add Snap backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ support for additional backends are welcome!
 | `pipx`                         | `[pipx]`    |                                       |
 | `cargo`                        | `[cargo]`   |                                       |
 | `rustup`                       | `[rustup]`  |                                       |
+| `snap`                         | `[snap]`    |                                       |
 | `winget`                       | `[winget]`  |                                       |
 | `xbps`                         | `[xbps]`    |                                       |
 
@@ -169,6 +170,10 @@ rustup = [
  "stable",
  # components: extra non-default components to install with this toolchain
  { package = "stable", components = ["rust-analyzer"] }
+]
+snap = [
+ "metapac",
+ { package = "metapac" }
 ]
 winget = [
  "metapac",

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -7,6 +7,7 @@ pub mod dnf;
 pub mod flatpak;
 pub mod pipx;
 pub mod rustup;
+pub mod snap;
 pub mod winget;
 pub mod xbps;
 
@@ -27,6 +28,7 @@ macro_rules! apply_public_backends {
         (Flatpak, flatpak),
         (Pipx, pipx),
         (Rustup, rustup),
+        (Snap, snap),
         (WinGet, winget),
         (Xbps, xbps) }
     };

--- a/src/backends/snap.rs
+++ b/src/backends/snap.rs
@@ -51,7 +51,6 @@ impl Backend for Snap {
             run_command(
                 ["snap", "install"]
                     .into_iter()
-                    .chain(Some("--assume-yes").filter(|_| no_confirm))
                     .chain(packages.keys().map(String::as_str)),
                 Perms::Sudo,
             )?;
@@ -65,7 +64,6 @@ impl Backend for Snap {
             run_command(
                 ["snap", "remove"]
                     .into_iter()
-                    .chain(Some("--assume-yes").filter(|_| no_confirm))
                     .chain(packages.iter().map(String::as_str)),
                 Perms::Sudo,
             )?;

--- a/src/backends/snap.rs
+++ b/src/backends/snap.rs
@@ -44,7 +44,7 @@ impl Backend for Snap {
 
     fn install_packages(
         packages: &BTreeMap<String, Self::InstallOptions>,
-        no_confirm: bool,
+        _no_confirm: bool,
         _: &Config,
     ) -> Result<()> {
         if !packages.is_empty() {
@@ -59,7 +59,7 @@ impl Backend for Snap {
         Ok(())
     }
 
-    fn remove_packages(packages: &BTreeSet<String>, no_confirm: bool, _: &Config) -> Result<()> {
+    fn remove_packages(packages: &BTreeSet<String>, _no_confirm: bool, _: &Config) -> Result<()> {
         if !packages.is_empty() {
             run_command(
                 ["snap", "remove"]

--- a/src/backends/snap.rs
+++ b/src/backends/snap.rs
@@ -1,0 +1,89 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use color_eyre::Result;
+use serde::{Deserialize, Serialize};
+
+use crate::cmd::{run_command, run_command_for_stdout};
+use crate::prelude::*;
+
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq, PartialOrd, Ord, derive_more::Display)]
+pub struct Snap;
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SnapQueryInfo {}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct SnapInstallOptions {}
+
+impl Backend for Snap {
+    type QueryInfo = SnapQueryInfo;
+    type InstallOptions = SnapInstallOptions;
+
+    fn map_managed_packages(
+        packages: BTreeMap<String, Self::InstallOptions>,
+        _: &Config,
+    ) -> Result<BTreeMap<String, Self::InstallOptions>> {
+        Ok(packages)
+    }
+
+    fn query_installed_packages(config: &Config) -> Result<BTreeMap<String, Self::QueryInfo>> {
+        if Self::version(config).is_err() {
+            return Ok(BTreeMap::new());
+        }
+
+        let output = run_command_for_stdout(["snap", "list"], Perms::Same, false)?;
+        
+        // Skip the first line which is the header
+        Ok(output
+            .lines()
+            .skip(1)
+            .filter_map(|line| line.split_whitespace().next())
+            .map(|name| (name.to_string(), SnapQueryInfo {}))
+            .collect())
+    }
+
+    fn install_packages(
+        packages: &BTreeMap<String, Self::InstallOptions>,
+        no_confirm: bool,
+        _: &Config,
+    ) -> Result<()> {
+        if !packages.is_empty() {
+            run_command(
+                ["snap", "install"]
+                    .into_iter()
+                    .chain(Some("--assume-yes").filter(|_| no_confirm))
+                    .chain(packages.keys().map(String::as_str)),
+                Perms::Sudo,
+            )?;
+        }
+
+        Ok(())
+    }
+
+    fn remove_packages(packages: &BTreeSet<String>, no_confirm: bool, _: &Config) -> Result<()> {
+        if !packages.is_empty() {
+            run_command(
+                ["snap", "remove"]
+                    .into_iter()
+                    .chain(Some("--assume-yes").filter(|_| no_confirm))
+                    .chain(packages.iter().map(String::as_str)),
+                Perms::Sudo,
+            )?;
+        }
+
+        Ok(())
+    }
+
+    fn version(_: &Config) -> Result<String> {
+        run_command_for_stdout(["snap", "--version"], Perms::Same, false)
+            .map(|output| {
+                output
+                    .lines()
+                    .next()
+                    .unwrap_or_default()
+                    .split_whitespace()
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            })
+    }
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -10,6 +10,7 @@ pub use crate::backends::dnf::{Dnf, DnfInstallOptions, DnfQueryInfo};
 pub use crate::backends::flatpak::{Flatpak, FlatpakInstallOptions, FlatpakQueryInfo};
 pub use crate::backends::pipx::{Pipx, PipxInstallOptions, PipxQueryOptions};
 pub use crate::backends::rustup::{Rustup, RustupInstallOptions, RustupQueryInfo};
+pub use crate::backends::snap::{Snap, SnapInstallOptions, SnapQueryInfo};
 pub use crate::backends::winget::{WinGet, WinGetInstallOptions, WinGetQueryInfo};
 pub use crate::backends::xbps::{Xbps, XbpsInstallOptions, XbpsQueryInfo};
 pub use crate::backends::{Backend, StringPackageStruct};


### PR DESCRIPTION
This PR adds support for the Snap package manager.

Changes:
- Added snap backend implementation
- Added snap to supported backends in README
- Added snap example in group files documentation

The implementation follows the same pattern as other backends, particularly taking inspiration from the apt backend structure.