### PR TITLE
Clean cache subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.6] - ?
+
+### Added
+
+- New subcommand `metapac clean-cache`! (#61)
+  
+  Allows you to clear the caches for all or selective backends.
+  `metapac clean-cache arch apt` to clean just the `arch` and `apt`
+  backends and just `metapac clear-cache` to clear all backends.
+
 ## [0.2.5] - 2024-11-24
 
 ### Added

--- a/src/backends/all.rs
+++ b/src/backends/all.rs
@@ -40,6 +40,11 @@ macro_rules! any {
             $($upper_backend,)*
         }
         impl AnyBackend {
+	    pub fn clean_cache(&self, config: &Config) -> Result<()> {
+		match self {
+		    $( AnyBackend::$upper_backend => $upper_backend::clean_cache(config), )*
+		}
+	    }
             pub fn version(&self, config: &Config) -> Result<String> {
                 match self {
                     $( AnyBackend::$upper_backend => $upper_backend::version(config), )*

--- a/src/backends/apt.rs
+++ b/src/backends/apt.rs
@@ -77,6 +77,12 @@ impl Backend for Apt {
         Ok(())
     }
 
+    fn clean_cache(config: &Config) -> Result<()> {
+        Self::version(config).map_or(Ok(()), |_| {
+            run_command(["apt-get", "autoclean"], Perms::Sudo)
+        })
+    }
+
     fn version(_: &Config) -> Result<String> {
         run_command_for_stdout(["apt", "--version"], Perms::Same, false)
     }

--- a/src/backends/arch.rs
+++ b/src/backends/arch.rs
@@ -238,6 +238,15 @@ impl Backend for Arch {
         Ok(())
     }
 
+    fn clean_cache(config: &Config) -> Result<()> {
+        Self::version(config).map_or(Ok(()), |_| {
+            run_command(
+                [config.arch_package_manager.as_command(), "-Sc"],
+                Perms::Same,
+            )
+        })
+    }
+
     fn version(config: &Config) -> Result<String> {
         run_command_for_stdout(
             [config.arch_package_manager.as_command(), "--version"],

--- a/src/backends/brew.rs
+++ b/src/backends/brew.rs
@@ -73,6 +73,12 @@ impl Backend for Brew {
         Ok(())
     }
 
+    fn clean_cache(config: &Config) -> Result<()> {
+        Self::version(config).map_or(Ok(()), |_| {
+            run_command(["brew", "cleanup", "--prune-prefix"], Perms::Same)
+        })
+    }
+
     fn version(_: &Config) -> Result<String> {
         run_command_for_stdout(["brew", "--version"], Perms::Same, false)
     }

--- a/src/backends/cargo.rs
+++ b/src/backends/cargo.rs
@@ -114,6 +114,12 @@ impl Backend for Cargo {
         Ok(())
     }
 
+    fn clean_cache(_: &Config) -> Result<()> {
+        run_command_for_stdout(["cargo-cache", "-V"], Perms::Same, false).map_or(Ok(()), |_| {
+            run_command(["cargo", "cache", "-a"], Perms::Same)
+        })
+    }
+
     fn version(_: &Config) -> Result<String> {
         run_command_for_stdout(["cargo", "--version"], Perms::Same, false)
     }

--- a/src/backends/dnf.rs
+++ b/src/backends/dnf.rs
@@ -108,6 +108,12 @@ impl Backend for Dnf {
         Ok(())
     }
 
+    fn clean_cache(config: &Config) -> Result<()> {
+        Self::version(config).map_or(Ok(()), |_| {
+            run_command(["dnf", "clean", "all"], Perms::Same)
+        })
+    }
+
     fn version(_: &Config) -> Result<String> {
         run_command_for_stdout(["dnf", "--version"], Perms::Same, false)
     }

--- a/src/backends/flatpak.rs
+++ b/src/backends/flatpak.rs
@@ -216,6 +216,12 @@ impl Backend for Flatpak {
         Ok(())
     }
 
+    fn clean_cache(config: &Config) -> Result<()> {
+        Self::version(config).map_or(Ok(()), |_| {
+            run_command(["flatpak", "remove", "--unused"], Perms::Same)
+        })
+    }
+
     fn version(_: &Config) -> Result<String> {
         run_command_for_stdout(["flatpak", "--version"], Perms::Same, false)
     }

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -63,5 +63,7 @@ pub trait Backend {
         config: &Config,
     ) -> Result<()>;
 
+    fn clean_cache(config: &Config) -> Result<()>;
+
     fn version(config: &Config) -> Result<String>;
 }

--- a/src/backends/pipx.rs
+++ b/src/backends/pipx.rs
@@ -78,6 +78,10 @@ impl Backend for Pipx {
         Ok(())
     }
 
+    fn clean_cache(_: &Config) -> Result<()> {
+        Ok(())
+    }
+
     fn version(_: &Config) -> Result<String> {
         run_command_for_stdout(["pipx", "--version"], Perms::Same, false)
     }

--- a/src/backends/rustup.rs
+++ b/src/backends/rustup.rs
@@ -121,6 +121,10 @@ impl Backend for Rustup {
         Ok(())
     }
 
+    fn clean_cache(_: &Config) -> Result<()> {
+        Ok(())
+    }
+
     fn version(_: &Config) -> Result<String> {
         run_command_for_stdout(["rustup", "--version"], Perms::Same, true)
     }

--- a/src/backends/snap.rs
+++ b/src/backends/snap.rs
@@ -72,6 +72,12 @@ impl Backend for Snap {
         Ok(())
     }
 
+    fn clean_cache(config: &Config) -> Result<()> {
+        Self::version(config).map_or(Ok(()), |_| {
+            run_command(["rm", "-rf", "/var/lib/snapd/cache/*"], Perms::Sudo)
+        })
+    }
+
     fn version(_: &Config) -> Result<String> {
         run_command_for_stdout(["snap", "--version"], Perms::Same, false).map(|output| {
             output

--- a/src/backends/winget.rs
+++ b/src/backends/winget.rs
@@ -95,6 +95,12 @@ impl Backend for WinGet {
         Ok(())
     }
 
+    // currently there is no way to do it for winget, see
+    // https://github.com/microsoft/winget-cli/issues/343
+    fn clean_cache(_: &Config) -> Result<()> {
+        Ok(())
+    }
+
     fn version(_: &Config) -> Result<String> {
         run_command_for_stdout(["winget", "--version"], Perms::Same, false)
     }

--- a/src/backends/xbps.rs
+++ b/src/backends/xbps.rs
@@ -91,6 +91,10 @@ impl Backend for Xbps {
         Ok(())
     }
 
+    fn clean_cache(config: &Config) -> Result<()> {
+        Self::version(config).map_or(Ok(()), |_| run_command(["xbps-remove", "-Oo"], Perms::Sudo))
+    }
+
     fn version(_: &Config) -> Result<String> {
         run_command_for_stdout(["xbps-query", "--version"], Perms::Same, false)
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,6 +31,7 @@ pub enum MainSubcommand {
     Sync(SyncCommand),
     Unmanaged(UnmanagedCommand),
     Backends(BackendsCommand),
+    Cache(CacheCommand),
 }
 
 #[derive(Args)]
@@ -86,3 +87,10 @@ pub struct UnmanagedCommand {}
 #[command(visible_alias("b"))]
 /// show the backends found by metapac
 pub struct BackendsCommand {}
+
+#[derive(Args)]
+/// Clean the cache of all the backends, or the ones specified
+pub struct CacheCommand {
+    #[arg(short, long)]
+    pub backends: Option<Vec<String>>,
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,7 +31,7 @@ pub enum MainSubcommand {
     Sync(SyncCommand),
     Unmanaged(UnmanagedCommand),
     Backends(BackendsCommand),
-    Cache(CacheCommand),
+    CleanCache(CleanCacheCommand),
 }
 
 #[derive(Args)]
@@ -89,8 +89,8 @@ pub struct UnmanagedCommand {}
 pub struct BackendsCommand {}
 
 #[derive(Args)]
-/// Clean the cache of all the backends, or the ones specified
-pub struct CacheCommand {
-    #[arg(short, long)]
+#[command(visible_alias("e"))]
+/// clean the caches of all the backends, or the just those specified
+pub struct CleanCacheCommand {
     pub backends: Option<Vec<String>>,
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -7,7 +7,7 @@ use dialoguer::Confirm;
 use strum::IntoEnumIterator;
 use toml_edit::{Array, DocumentMut, Item, Value};
 
-use crate::cli::BackendsCommand;
+use crate::cli::{BackendsCommand, CacheCommand};
 use crate::prelude::*;
 use crate::review::review;
 
@@ -44,6 +44,7 @@ impl MainArguments {
             MainSubcommand::Sync(sync) => sync.run(&managed, &config),
             MainSubcommand::Unmanaged(unmanaged) => unmanaged.run(&managed, &config),
             MainSubcommand::Backends(found_backends) => found_backends.run(&config),
+            MainSubcommand::Cache(backends) => backends.run(&config),
         }
     }
 }
@@ -186,6 +187,17 @@ impl BackendsCommand {
             );
         }
 
+        Ok(())
+    }
+}
+
+impl CacheCommand {
+    fn run(&self, config: &Config) -> Result<()> {
+        for backend in AnyBackend::iter() {
+            println!("Cleaning cache for {backend}\n\n");
+            backend.clean_cache(config)?
+        }
+        println!("\n\nCleaned all available backends");
         Ok(())
     }
 }


### PR DESCRIPTION
Implements the `cache` subcommand to clean up cache of the backends. Selective filtering of backends isn't implemented yet, need to do that. 