### PR TITLE
Do not skip the first line output of `flatpak list`/`flatpak pin`

### DIFF
--- a/src/backends/flatpak.rs
+++ b/src/backends/flatpak.rs
@@ -81,7 +81,6 @@ impl Backend for Flatpak {
             run_command_for_stdout(["flatpak", "pin", "--system"], Perms::Same, false)?;
         let sys_explicit_runtimes = sys_explicit_runtimes_out
             .lines()
-            .skip(1)
             .map(|x| {
                 (
                     x.trim().split('/').nth(1).unwrap().to_owned(),
@@ -111,7 +110,6 @@ impl Backend for Flatpak {
             run_command_for_stdout(["flatpak", "pin", "--user"], Perms::Same, false)?;
         let user_explicit_runtimes = user_explicit_runtimes_out
             .lines()
-            .skip(1)
             .map(|x| {
                 (
                     x.trim().split('/').nth(1).unwrap().to_owned(),

--- a/src/backends/flatpak.rs
+++ b/src/backends/flatpak.rs
@@ -90,7 +90,6 @@ impl Backend for Flatpak {
             .filter(|(runtime, _)| {
                 sys_explicit_runtimes_installed
                     .lines()
-                    .skip(1)
                     .map(|x| x.trim())
                     .contains(&runtime.as_str())
             });
@@ -119,7 +118,6 @@ impl Backend for Flatpak {
             .filter(|(runtime, _)| {
                 user_explicit_runtimes_installed
                     .lines()
-                    .skip(1)
                     .map(|x| x.trim())
                     .contains(&runtime.as_str())
             });


### PR DESCRIPTION
`flatpak list`/`flatpak pin` does not output the first line if the stdout is not a TTY.

```
$ flatpak list --columns application
Application ID
org.fedoraproject.Platform

$ flatpak list --columns application | cat
org.fedoraproject.Platform

$ flatpak pin --system
Pinned patterns:
  runtime/org.fedoraproject.Platform/x86_64/f41

$ flatpak pin --system | cat
  runtime/org.fedoraproject.Platform/x86_64/f41
```