### PR TITLE
Fixed pipx uninstall bug

### DIFF
--- a/src/backends/pipx.rs
+++ b/src/backends/pipx.rs
@@ -55,13 +55,8 @@ impl Backend for Pipx {
     }
 
     fn uninstall(packages: &BTreeSet<String>, _: bool, _: &Config) -> Result<()> {
-        if !packages.is_empty() {
-            run_command(
-                ["pipx", "uninstall"]
-                    .into_iter()
-                    .chain(packages.iter().map(String::as_str)),
-                Perms::Same,
-            )?;
+        for package in packages {
+            run_command(["pipx", "uninstall", package], Perms::Same)?;
         }
 
         Ok(())


### PR DESCRIPTION
For whatever reason, `pipx` does not allow multiple arguments when uninstalling, leading to the `clean` command failing when multiple non-managed `pipx` packages are installed. This can trivially be fixed by looping over the package list.