### PR TITLE
Fix duplicate packages in case of new group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fixed a bug with packages being added twice when the backend didn't yet
+  exist in a group file with the `metapac add` command. Fixed in (#99),
+  thanks @DominicD!
+
 ## [0.4.0] - 2025-07-27
 
 Another big release 🚢, with no breaking changes this time 🎉🎉. In this


### PR DESCRIPTION
today running this command (if the group does not yet exist):

`metapac add -p test,test1 -g terminal --backend dnf`

results in metapac creating the file ~/.confg/metapac/groups/terminal.toml

with this content:

> dnf = ["test,test1", "test,test1"]

This happens if the backend does not yet have an entry. With the fix the entry is either added or extended not both.
With the fix the content is correctly:
> dnf = ["test,test1"]
