### PR TITLE
Cargo backend: Add option to install with --locked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: ci
 
-on: push
+on:
+  pull_request:
+    branches:
+      - main
 
 env:
   RUST_BACKTRACE: 1

--- a/README.md
+++ b/README.md
@@ -203,8 +203,6 @@ laptop = ["example_group"]
 server = ["example_group"]
 
 # Whether to default to installing cargo packages with --locked option.
-# This setting can be overriden on a per-package base using 
-# { systemwide = false|true }.
 # Default: false
 cargo_default_locked = true
 ```

--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ vscode_variant = "code"
 # Default: true
 flatpak_default_systemwide = true
 
+# Whether to default to installing cargo packages with the --locked option.
+# Default: false
+cargo_default_locked = true
+
 # Whether to use the [hostname_groups] config table to decide which
 # group files to use or to use all files in the groups folder.
 # Default: false
@@ -200,10 +204,6 @@ hostname_groups_enabled = true
 pc = ["example_group"]
 laptop = ["example_group"]
 server = ["example_group"]
-
-# Whether to default to installing cargo packages with the --locked option.
-# Default: false
-cargo_default_locked = true
 ```
 
 ## Group Files

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ for additional backends are always welcome!
 
 # Backends to enable for most of metapac's behavior. See the README.md or
 # run `metapac backends` for the list of backend names
-# Default: []
+ # Default: []
 enabled_backends = ["arch"]
 
 # Since pacman, pamac, paru, pikaur and yay all operate on the same package database
@@ -201,6 +201,12 @@ hostname_groups_enabled = true
 pc = ["example_group"]
 laptop = ["example_group"]
 server = ["example_group"]
+
+# Whether to default to installing cargo packages with --locked option.
+# This setting can be overriden on a per-paclage base using 
+# { systemwide = false|true }.
+# Default: false
+cargo_default_locked = true
 ```
 
 ## Group Files

--- a/README.md
+++ b/README.md
@@ -184,8 +184,7 @@ arch_package_manager = "paru"
 vscode_variant = "code"
 
 # Whether to default to installing flatpak packages systemwide or for the
-# current user. This setting can be overridden on a per-package basis using
-# { systemwide = false|true }.
+# current user. This setting can be overridden on a per-package basis.
 # Default: true
 flatpak_default_systemwide = true
 
@@ -202,7 +201,7 @@ pc = ["example_group"]
 laptop = ["example_group"]
 server = ["example_group"]
 
-# Whether to default to installing cargo packages with --locked option.
+# Whether to default to installing cargo packages with the --locked option.
 # Default: false
 cargo_default_locked = true
 ```

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ laptop = ["example_group"]
 server = ["example_group"]
 
 # Whether to default to installing cargo packages with --locked option.
-# This setting can be overriden on a per-paclage base using 
+# This setting can be overriden on a per-package base using 
 # { systemwide = false|true }.
 # Default: false
 cargo_default_locked = true

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ for additional backends are always welcome!
 
 # Backends to enable for most of metapac's behavior. See the README.md or
 # run `metapac backends` for the list of backend names
- # Default: []
+# Default: []
 enabled_backends = ["arch"]
 
 # Since pacman, pamac, paru, pikaur and yay all operate on the same package database

--- a/README.md
+++ b/README.md
@@ -176,21 +176,21 @@ enabled_backends = ["arch"]
 # Default: "pacman"
 arch_package_manager = "paru"
 
-# Since VSCode and VSCodium both operate on the same package database
-# they are mutually exclusive and so you must pick which one you want
-# metapac to use.
-# Must be one of: ["code", "codium"]
-# Default: "code"
-vscode_variant = "code"
+# Whether to default to installing cargo packages with the --locked option.
+# Default: false
+cargo_default_locked = true
 
 # Whether to default to installing flatpak packages systemwide or for the
 # current user. This setting can be overridden on a per-package basis.
 # Default: true
 flatpak_default_systemwide = true
 
-# Whether to default to installing cargo packages with the --locked option.
-# Default: false
-cargo_default_locked = true
+# Since VSCode and VSCodium both operate on the same package database
+# they are mutually exclusive and so you must pick which one you want
+# metapac to use.
+# Must be one of: ["code", "codium"]
+# Default: "code"
+vscode_variant = "code"
 
 # Whether to use the [hostname_groups] config table to decide which
 # group files to use or to use all files in the groups folder.

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ bun = [
 cargo = [
  "metapac",
  # see cargo docs for info on the options
- { package = "metapac", options = { git = "https://github.com/ripytide/metapac", all_features = true, no_default_features = false, features = [ "feature1", ] } },
+ { package = "metapac", options = { git = "https://github.com/ripytide/metapac", all_features = true, no_default_features = false, features = [ "feature1", ], locked = true } },
 ]
 dnf = [
  "metapac",

--- a/src/backends/cargo.rs
+++ b/src/backends/cargo.rs
@@ -27,6 +27,8 @@ pub struct CargoOptions {
     no_default_features: bool,
     #[serde_inline_default(CargoOptions::default().features)]
     features: Vec<String>,
+    #[serde_inline_default(CargoOptions::default().locked)]
+    locked: bool,
 }
 
 impl Backend for Cargo {
@@ -65,6 +67,7 @@ impl Backend for Cargo {
             run_command(
                 ["cargo", "install"]
                     .into_iter()
+                    .chain(Some("--locked").into_iter().filter(|_| options.locked))
                     .chain(Some("--git").into_iter().filter(|_| options.git.is_some()))
                     .chain(options.git.as_deref())
                     .chain(
@@ -153,6 +156,8 @@ fn extract_packages(contents: &str) -> Result<BTreeMap<String, CargoOptions>> {
                 .map(|value| value.as_str().unwrap().to_string())
                 .collect();
 
+            let locked = false;
+
             (
                 name.to_string(),
                 CargoOptions {
@@ -161,6 +166,7 @@ fn extract_packages(contents: &str) -> Result<BTreeMap<String, CargoOptions>> {
                     all_features,
                     no_default_features,
                     features,
+                    locked,
                 },
             )
         })

--- a/src/backends/cargo.rs
+++ b/src/backends/cargo.rs
@@ -156,8 +156,6 @@ fn extract_packages(contents: &str) -> Result<BTreeMap<String, CargoOptions>> {
                 .map(|value| value.as_str().unwrap().to_string())
                 .collect();
 
-            let locked = false;
-
             (
                 name.to_string(),
                 CargoOptions {
@@ -166,7 +164,7 @@ fn extract_packages(contents: &str) -> Result<BTreeMap<String, CargoOptions>> {
                     all_features,
                     no_default_features,
                     features,
-                    locked,
+                    locked: false, //cargo does not track if the install happened with --locked
                 },
             )
         })

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,12 +22,12 @@ pub struct Config {
     pub vscode_variant: VsCodeVariant,
     #[serde_inline_default(Config::default().flatpak_default_systemwide)]
     pub flatpak_default_systemwide: bool,
+    #[serde_inline_default(Config::default().cargo_default_locked)]
+    pub cargo_default_locked: bool,
     #[serde_inline_default(Config::default().hostname_groups_enabled)]
     pub hostname_groups_enabled: bool,
     #[serde_inline_default(Config::default().hostname_groups)]
     pub hostname_groups: BTreeMap<String, Vec<String>>,
-    #[serde_inline_default(Config::default().cargo_default_locked)]
-    pub cargo_default_locked: bool,
 }
 impl Default for Config {
     fn default() -> Self {
@@ -36,9 +36,9 @@ impl Default for Config {
             arch_package_manager: ArchPackageManager::default(),
             vscode_variant: VsCodeVariant::default(),
             flatpak_default_systemwide: true,
+            cargo_default_locked: false,
             hostname_groups_enabled: false,
             hostname_groups: BTreeMap::new(),
-            cargo_default_locked: false,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,12 +18,12 @@ pub struct Config {
     pub enabled_backends: BTreeSet<AnyBackend>,
     #[serde_inline_default(Config::default().arch_package_manager)]
     pub arch_package_manager: ArchPackageManager,
-    #[serde_inline_default(Config::default().vscode_variant)]
-    pub vscode_variant: VsCodeVariant,
-    #[serde_inline_default(Config::default().flatpak_default_systemwide)]
-    pub flatpak_default_systemwide: bool,
     #[serde_inline_default(Config::default().cargo_default_locked)]
     pub cargo_default_locked: bool,
+    #[serde_inline_default(Config::default().flatpak_default_systemwide)]
+    pub flatpak_default_systemwide: bool,
+    #[serde_inline_default(Config::default().vscode_variant)]
+    pub vscode_variant: VsCodeVariant,
     #[serde_inline_default(Config::default().hostname_groups_enabled)]
     pub hostname_groups_enabled: bool,
     #[serde_inline_default(Config::default().hostname_groups)]
@@ -34,9 +34,9 @@ impl Default for Config {
         Config {
             enabled_backends: BTreeSet::new(),
             arch_package_manager: ArchPackageManager::default(),
-            vscode_variant: VsCodeVariant::default(),
-            flatpak_default_systemwide: true,
             cargo_default_locked: false,
+            flatpak_default_systemwide: true,
+            vscode_variant: VsCodeVariant::default(),
             hostname_groups_enabled: false,
             hostname_groups: BTreeMap::new(),
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,8 @@ pub struct Config {
     pub hostname_groups_enabled: bool,
     #[serde_inline_default(Config::default().hostname_groups)]
     pub hostname_groups: BTreeMap<String, Vec<String>>,
+    #[serde_inline_default(Config::default().cargo_default_locked)]
+    pub cargo_default_locked: bool,
 }
 impl Default for Config {
     fn default() -> Self {
@@ -36,6 +38,7 @@ impl Default for Config {
             flatpak_default_systemwide: true,
             hostname_groups_enabled: false,
             hostname_groups: BTreeMap::new(),
+            cargo_default_locked: false,
         }
     }
 }


### PR DESCRIPTION
It is common to use --locked with cargo install