### PR TITLE
add: config sections per backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- ‼️ Breaking Change ‼️ backend specific configs have been moved into
+  sections for each backend and `flatpak_default_systemwide` has been
+  renamed to `flatpak.systemwide` (#117), thanks @steven-omaha! For
+  example:
+
+  ```toml
+  # instead of this
+  arch_package_manager = "paru"
+  flatpak_default_systemwide = false
+  vscode_variant = "code"
+
+  # do this
+  [arch]
+  package_manager = "paru"
+  [flatpak]
+  # notice this is now just systemwide and not default_systemwide
+  systemwide = false
+  [vscode]
+  variant = "code"
+  ```
+
 ## [0.4.1] - 2025-08-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -169,29 +169,6 @@ for additional backends are always welcome!
 # Default: []
 enabled_backends = ["arch"]
 
-# Since pacman, pamac, paru, pikaur and yay all operate on the same package database
-# they are mutually exclusive and so you must pick which one you want
-# metapac to use.
-# Must be one of: ["pacman", "pamac", "paru", "pikaur", "yay"]
-# Default: "pacman"
-arch_package_manager = "paru"
-
-# Whether to default to installing cargo packages with the --locked option.
-# Default: false
-cargo_default_locked = true
-
-# Whether to default to installing flatpak packages systemwide or for the
-# current user. This setting can be overridden on a per-package basis.
-# Default: true
-flatpak_default_systemwide = true
-
-# Since VSCode and VSCodium both operate on the same package database
-# they are mutually exclusive and so you must pick which one you want
-# metapac to use.
-# Must be one of: ["code", "codium"]
-# Default: "code"
-vscode_variant = "code"
-
 # Whether to use the [hostname_groups] config table to decide which
 # group files to use or to use all files in the groups folder.
 # Default: false
@@ -204,6 +181,34 @@ hostname_groups_enabled = true
 pc = ["example_group"]
 laptop = ["example_group"]
 server = ["example_group"]
+
+[arch]
+# Since pacman, pamac, paru, pikaur and yay all operate on the same package database
+# they are mutually exclusive and so you must pick which one you want
+# metapac to use.
+# Must be one of: ["pacman", "pamac", "paru", "pikaur", "yay"]
+# Default: "pacman"
+package_manager = "paru"
+
+[cargo]
+# Whether to default to installing cargo packages with the --locked option.
+# Default: false
+default_locked = true
+
+[flatpak]
+# Whether to default to installing flatpak packages systemwide or for the
+# current user. This setting can be overridden on a per-package basis.
+# Default: true
+default_systemwide = true
+
+[vscode]
+# Since VSCode and VSCodium both operate on the same package database
+# they are mutually exclusive and so you must pick which one you want
+# metapac to use.
+# Must be one of: ["code", "codium"]
+# Default: "code"
+variant = "code"
+
 ```
 
 ## Group Files

--- a/README.md
+++ b/README.md
@@ -208,7 +208,6 @@ systemwide = true
 # Must be one of: ["code", "codium"]
 # Default: "code"
 variant = "code"
-
 ```
 
 ## Group Files

--- a/README.md
+++ b/README.md
@@ -193,13 +193,13 @@ package_manager = "paru"
 [cargo]
 # Whether to default to installing cargo packages with the --locked option.
 # Default: false
-default_locked = true
+locked = true
 
 [flatpak]
 # Whether to default to installing flatpak packages systemwide or for the
 # current user. This setting can be overridden on a per-package basis.
 # Default: true
-default_systemwide = true
+systemwide = true
 
 [vscode]
 # Since VSCode and VSCodium both operate on the same package database

--- a/src/backends/arch.rs
+++ b/src/backends/arch.rs
@@ -27,7 +27,7 @@ impl Backend for Arch {
 
         let groups = run_command_for_stdout(
             [
-                config.arch_package_manager.as_command(),
+                config.arch.package_manager.as_command(),
                 "--sync",
                 "--groups",
                 "--quiet",
@@ -40,7 +40,7 @@ impl Backend for Arch {
             if let Some(options) = packages.remove(group) {
                 let group_packages = run_command_for_stdout(
                     [
-                        config.arch_package_manager.as_command(),
+                        config.arch.package_manager.as_command(),
                         "--sync",
                         "--groups",
                         "--quiet",
@@ -66,7 +66,7 @@ impl Backend for Arch {
 
         let all_packages: BTreeSet<String> = run_command_for_stdout(
             [
-                config.arch_package_manager.as_command(),
+                config.arch.package_manager.as_command(),
                 "--sync",
                 "--list",
                 "--quiet",
@@ -117,7 +117,7 @@ impl Backend for Arch {
 
         let explicit_packages = run_command_for_stdout(
             [
-                config.arch_package_manager.as_command(),
+                config.arch.package_manager.as_command(),
                 "--query",
                 "--explicit",
                 "--quiet",
@@ -143,14 +143,14 @@ impl Backend for Arch {
         if !packages.is_empty() {
             run_command(
                 [
-                    config.arch_package_manager.as_command(),
+                    config.arch.package_manager.as_command(),
                     "--sync",
                     "--asexplicit",
                 ]
                 .into_iter()
                 .chain(Some("--noconfirm").filter(|_| no_confirm))
                 .chain(packages.keys().map(String::as_str)),
-                config.arch_package_manager.change_perms(),
+                config.arch.package_manager.change_perms(),
             )?;
         }
 
@@ -161,18 +161,18 @@ impl Backend for Arch {
         if !packages.is_empty() {
             run_command(
                 [
-                    config.arch_package_manager.as_command(),
+                    config.arch.package_manager.as_command(),
                     "--database",
                     "--asdeps",
                 ]
                 .into_iter()
                 .chain(packages.iter().map(String::as_str)),
-                config.arch_package_manager.change_perms(),
+                config.arch.package_manager.change_perms(),
             )?;
 
             let orphans_output = run_command_for_stdout(
                 [
-                    config.arch_package_manager.as_command(),
+                    config.arch.package_manager.as_command(),
                     "--query",
                     "--deps",
                     "--unrequired",
@@ -185,7 +185,7 @@ impl Backend for Arch {
 
             run_command(
                 [
-                    config.arch_package_manager.as_command(),
+                    config.arch.package_manager.as_command(),
                     "--remove",
                     "--nosave",
                     "--recursive",
@@ -193,7 +193,7 @@ impl Backend for Arch {
                 .into_iter()
                 .chain(Some("--noconfirm").filter(|_| no_confirm))
                 .chain(orphans),
-                config.arch_package_manager.change_perms(),
+                config.arch.package_manager.change_perms(),
             )?;
         }
 
@@ -204,7 +204,7 @@ impl Backend for Arch {
         Self::version(config).map_or(Ok(()), |_| {
             run_command(
                 [
-                    config.arch_package_manager.as_command(),
+                    config.arch.package_manager.as_command(),
                     "--sync",
                     "--clean",
                 ],
@@ -215,7 +215,7 @@ impl Backend for Arch {
 
     fn version(config: &Config) -> Result<String> {
         run_command_for_stdout(
-            [config.arch_package_manager.as_command(), "--version"],
+            [config.arch.package_manager.as_command(), "--version"],
             Perms::Same,
             false,
         )

--- a/src/backends/cargo.rs
+++ b/src/backends/cargo.rs
@@ -70,7 +70,7 @@ impl Backend for Cargo {
                     .chain(
                         Some("--locked")
                             .into_iter()
-                            .filter(|_| options.locked.unwrap_or(config.cargo_default_locked)),
+                            .filter(|_| options.locked.unwrap_or(config.cargo.default_locked)),
                     )
                     .chain(Some("--git").into_iter().filter(|_| options.git.is_some()))
                     .chain(options.git.as_deref())

--- a/src/backends/cargo.rs
+++ b/src/backends/cargo.rs
@@ -70,7 +70,7 @@ impl Backend for Cargo {
                     .chain(
                         Some("--locked")
                             .into_iter()
-                            .filter(|_| options.locked.unwrap_or(config.cargo.default_locked)),
+                            .filter(|_| options.locked.unwrap_or(config.cargo.locked)),
                     )
                     .chain(Some("--git").into_iter().filter(|_| options.git.is_some()))
                     .chain(options.git.as_deref())

--- a/src/backends/flatpak.rs
+++ b/src/backends/flatpak.rs
@@ -157,7 +157,7 @@ impl Backend for Flatpak {
                     "install",
                     if options
                         .systemwide
-                        .unwrap_or(config.flatpak_default_systemwide)
+                        .unwrap_or(config.flatpak.default_systemwide)
                     {
                         "--system"
                     } else {

--- a/src/backends/flatpak.rs
+++ b/src/backends/flatpak.rs
@@ -155,10 +155,7 @@ impl Backend for Flatpak {
                 [
                     "flatpak",
                     "install",
-                    if options
-                        .systemwide
-                        .unwrap_or(config.flatpak.default_systemwide)
-                    {
+                    if options.systemwide.unwrap_or(config.flatpak.systemwide) {
                         "--system"
                     } else {
                         "--user"

--- a/src/backends/vscode.rs
+++ b/src/backends/vscode.rs
@@ -33,7 +33,7 @@ impl Backend for VsCode {
         }
 
         let names = run_command_for_stdout(
-            [config.vscode_variant.as_command(), "--list-extensions"],
+            [config.vscode.variant.as_command(), "--list-extensions"],
             Perms::Same,
             true,
         )?
@@ -48,7 +48,7 @@ impl Backend for VsCode {
         for package in packages.keys() {
             run_command(
                 [
-                    config.vscode_variant.as_command(),
+                    config.vscode.variant.as_command(),
                     "--install-extension",
                     package,
                 ],
@@ -63,7 +63,7 @@ impl Backend for VsCode {
         for package in packages {
             run_command(
                 [
-                    config.vscode_variant.as_command(),
+                    config.vscode.variant.as_command(),
                     "--uninstall-extension",
                     package,
                 ],
@@ -80,7 +80,7 @@ impl Backend for VsCode {
 
     fn version(config: &Config) -> Result<String> {
         run_command_for_stdout(
-            [config.vscode_variant.as_command(), "--version"],
+            [config.vscode.variant.as_command(), "--version"],
             Perms::Same,
             false,
         )

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,21 +22,21 @@ pub struct Config {
     #[serde_inline_default(Config::default().hostname_groups)]
     pub hostname_groups: BTreeMap<String, Vec<String>>,
     #[serde_inline_default(Config::default().arch)]
-    pub arch: Arch,
+    pub arch: ArchConfig,
     #[serde_inline_default(Config::default().cargo)]
-    pub cargo: Cargo,
+    pub cargo: CargoConfig,
     #[serde_inline_default(Config::default().flatpak)]
-    pub flatpak: Flatpak,
+    pub flatpak: FlatpakConfig,
     #[serde_inline_default(Config::default().vscode)]
-    pub vscode: VsCode,
+    pub vscode: VsCodeConfig,
 }
 
 #[serde_inline_default]
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[derive(Default)]
-pub struct Arch {
-    #[serde_inline_default(Arch::default().package_manager)]
+pub struct ArchConfig {
+    #[serde_inline_default(ArchConfig::default().package_manager)]
     pub package_manager: ArchPackageManager,
 }
 
@@ -44,25 +44,30 @@ pub struct Arch {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[derive(Default)]
-pub struct Cargo {
-    #[serde_inline_default(Cargo::default().default_locked)]
-    pub default_locked: bool,
+pub struct CargoConfig {
+    #[serde_inline_default(CargoConfig::default().locked)]
+    pub locked: bool,
+}
+
+#[serde_inline_default]
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FlatpakConfig {
+    #[serde_inline_default(FlatpakConfig::default().systemwide)]
+    pub systemwide: bool,
+}
+
+impl Default for FlatpakConfig {
+    fn default() -> Self {
+        Self { systemwide: true }
+    }
 }
 
 #[serde_inline_default]
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[derive(Default)]
-pub struct Flatpak {
-    #[serde_inline_default(Flatpak::default().default_systemwide)]
-    pub default_systemwide: bool,
-}
-
-#[serde_inline_default]
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-#[derive(Default)]
-pub struct VsCode {
+pub struct VsCodeConfig {
     #[serde_inline_default(VsCodeVariant::default())]
     pub variant: VsCodeVariant,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,7 +53,6 @@ pub struct FlatpakConfig {
     #[serde_inline_default(FlatpakConfig::default().systemwide)]
     pub systemwide: bool,
 }
-
 impl Default for FlatpakConfig {
     fn default() -> Self {
         Self { systemwide: true }

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,10 @@ use crate::prelude::*;
 pub struct Config {
     #[serde_inline_default(Config::default().enabled_backends)]
     pub enabled_backends: BTreeSet<AnyBackend>,
+    #[serde_inline_default(Config::default().hostname_groups_enabled)]
+    pub hostname_groups_enabled: bool,
+    #[serde_inline_default(Config::default().hostname_groups)]
+    pub hostname_groups: BTreeMap<String, Vec<String>>,
     #[serde_inline_default(Config::default().arch)]
     pub arch: Arch,
     #[serde_inline_default(Config::default().cargo)]
@@ -25,10 +29,6 @@ pub struct Config {
     pub flatpak: Flatpak,
     #[serde_inline_default(Config::default().vscode)]
     pub vscode: VsCode,
-    #[serde_inline_default(Config::default().hostname_groups_enabled)]
-    pub hostname_groups_enabled: bool,
-    #[serde_inline_default(Config::default().hostname_groups)]
-    pub hostname_groups: BTreeMap<String, Vec<String>>,
 }
 
 #[serde_inline_default]

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,9 +11,8 @@ use crate::prelude::*;
 
 // Update README if fields change.
 #[serde_inline_default]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
-#[derive(Default)]
 pub struct Config {
     #[serde_inline_default(Config::default().enabled_backends)]
     pub enabled_backends: BTreeSet<AnyBackend>,
@@ -32,18 +31,16 @@ pub struct Config {
 }
 
 #[serde_inline_default]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
-#[derive(Default)]
 pub struct ArchConfig {
     #[serde_inline_default(ArchConfig::default().package_manager)]
     pub package_manager: ArchPackageManager,
 }
 
 #[serde_inline_default]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
-#[derive(Default)]
 pub struct CargoConfig {
     #[serde_inline_default(CargoConfig::default().locked)]
     pub locked: bool,
@@ -64,9 +61,8 @@ impl Default for FlatpakConfig {
 }
 
 #[serde_inline_default]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
-#[derive(Default)]
 pub struct VsCodeConfig {
     #[serde_inline_default(VsCodeVariant::default())]
     pub variant: VsCodeVariant,

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,15 +13,16 @@ use crate::prelude::*;
 #[serde_inline_default]
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+#[derive(Default)]
 pub struct Config {
     #[serde_inline_default(Config::default().enabled_backends)]
     pub enabled_backends: BTreeSet<AnyBackend>,
-    #[serde_inline_default(Config::default().arch_package_manager)]
-    pub arch_package_manager: ArchPackageManager,
-    #[serde_inline_default(Config::default().cargo_default_locked)]
-    pub cargo_default_locked: bool,
-    #[serde_inline_default(Config::default().flatpak_default_systemwide)]
-    pub flatpak_default_systemwide: bool,
+    #[serde_inline_default(Config::default().arch)]
+    pub arch: Arch,
+    #[serde_inline_default(Config::default().cargo)]
+    pub cargo: Cargo,
+    #[serde_inline_default(Config::default().flatpak)]
+    pub flatpak: Flatpak,
     #[serde_inline_default(Config::default().vscode_variant)]
     pub vscode_variant: VsCodeVariant,
     #[serde_inline_default(Config::default().hostname_groups_enabled)]
@@ -29,18 +30,32 @@ pub struct Config {
     #[serde_inline_default(Config::default().hostname_groups)]
     pub hostname_groups: BTreeMap<String, Vec<String>>,
 }
-impl Default for Config {
-    fn default() -> Self {
-        Config {
-            enabled_backends: BTreeSet::new(),
-            arch_package_manager: ArchPackageManager::default(),
-            cargo_default_locked: false,
-            flatpak_default_systemwide: true,
-            vscode_variant: VsCodeVariant::default(),
-            hostname_groups_enabled: false,
-            hostname_groups: BTreeMap::new(),
-        }
-    }
+
+#[serde_inline_default]
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[derive(Default)]
+pub struct Arch {
+    #[serde_inline_default(Arch::default().package_manager)]
+    pub package_manager: ArchPackageManager,
+}
+
+#[serde_inline_default]
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[derive(Default)]
+pub struct Cargo {
+    #[serde_inline_default(Cargo::default().default_locked)]
+    pub default_locked: bool,
+}
+
+#[serde_inline_default]
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[derive(Default)]
+pub struct Flatpak {
+    #[serde_inline_default(Flatpak::default().default_systemwide)]
+    pub default_systemwide: bool,
 }
 
 impl Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,8 +23,8 @@ pub struct Config {
     pub cargo: Cargo,
     #[serde_inline_default(Config::default().flatpak)]
     pub flatpak: Flatpak,
-    #[serde_inline_default(Config::default().vscode_variant)]
-    pub vscode_variant: VsCodeVariant,
+    #[serde_inline_default(Config::default().vscode)]
+    pub vscode: VsCode,
     #[serde_inline_default(Config::default().hostname_groups_enabled)]
     pub hostname_groups_enabled: bool,
     #[serde_inline_default(Config::default().hostname_groups)]
@@ -56,6 +56,15 @@ pub struct Cargo {
 pub struct Flatpak {
     #[serde_inline_default(Flatpak::default().default_systemwide)]
     pub default_systemwide: bool,
+}
+
+#[serde_inline_default]
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[derive(Default)]
+pub struct VsCode {
+    #[serde_inline_default(VsCodeVariant::default())]
+    pub variant: VsCodeVariant,
 }
 
 impl Config {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -23,6 +23,8 @@ pub use crate::cli::{
     SyncCommand, UninstallCommand, UnmanagedCommand,
 };
 pub use crate::cmd::Perms;
-pub use crate::config::{ArchPackageManager, Config, VsCodeVariant};
+pub use crate::config::{
+    ArchConfig, ArchPackageManager, CargoConfig, Config, FlatpakConfig, VsCodeConfig, VsCodeVariant,
+};
 pub use crate::groups::Groups;
 pub use crate::package::{Hooks, Package};


### PR DESCRIPTION
Implements #106.

Use this config file, and it should work.

Couldn't test flatpak and vscode because I don't use them.

`~/.config/metapac/config.toml`
```toml
enabled_backends = ["arch", "cargo"]

[arch]
package_manager = "paru"

[cargo]
default_locked = true
```